### PR TITLE
Fix race

### DIFF
--- a/control.go
+++ b/control.go
@@ -11,11 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"sync"
+
 	"golang.org/x/net/context"
 )
 
 var (
-	randr *rand.Rand
+	randr    *rand.Rand
+	mutRandr sync.Mutex
 )
 
 func init() {
@@ -135,7 +138,9 @@ func hostInfo(addr string, defaultPort int) (*HostInfo, error) {
 }
 
 func shuffleHosts(hosts []*HostInfo) []*HostInfo {
+	mutRandr.Lock()
 	perm := randr.Perm(len(hosts))
+	mutRandr.Unlock()
 	shuffled := make([]*HostInfo, len(hosts))
 
 	for i, host := range hosts {


### PR DESCRIPTION
```console
==================
WARNING: DATA RACE
Read at 0x00c42023c000 by goroutine 87:
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:231 +0x3f
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:81 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/go/src/math/rand/rand.go:95 +0x38
  math/rand.(*Rand).Int31n()
      /usr/local/go/src/math/rand/rand.go:127 +0xd2
  math/rand.(*Rand).Intn()
      /usr/local/go/src/math/rand/rand.go:144 +0x52
  math/rand.(*Rand).Perm()
      /usr/local/go/src/math/rand/rand.go:197 +0xa2
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).shuffleDial()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:109 +0x6f
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).connect()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:153 +0x114
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.NewSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/session.go:153 +0x141e
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/cluster.go:148 +0x8f
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).createSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:115 +0x173
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).Start()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:140 +0xbe
  github.com/znly/zenly-engine/common/services.Run.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:80 +0xc7

Previous write at 0x00c42023c000 by goroutine 21:
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:231 +0x58
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:81 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/go/src/math/rand/rand.go:95 +0x38
  math/rand.(*Rand).Int31n()
      /usr/local/go/src/math/rand/rand.go:127 +0xd2
  math/rand.(*Rand).Intn()
      /usr/local/go/src/math/rand/rand.go:144 +0x52
  math/rand.(*Rand).Perm()
      /usr/local/go/src/math/rand/rand.go:197 +0xa2
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).shuffleDial()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:109 +0x6f
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).connect()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:153 +0x114
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.NewSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/session.go:153 +0x141e
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/cluster.go:148 +0x8f
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).createSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:115 +0x173
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).Start()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:140 +0xbe
  github.com/znly/zenly-engine/common/services.Run.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:80 +0xc7

Goroutine 87 (running) created at:
  github.com/znly/zenly-engine/common/services.Run()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:96 +0x1e7
  main.main.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:123 +0xe01
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:572 +0x801
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:662 +0x458
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:618 +0x38
  main.main()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:187 +0xf09

Goroutine 21 (running) created at:
  github.com/znly/zenly-engine/common/services.Run()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:96 +0x1e7
  main.main.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:123 +0xe01
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:572 +0x801
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:662 +0x458
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:618 +0x38
  main.main()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:187 +0xf09
==================
==================
WARNING: DATA RACE
Read at 0x00c42023c008 by goroutine 87:
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:231 +0x9a
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:81 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/go/src/math/rand/rand.go:95 +0x38
  math/rand.(*Rand).Int31n()
      /usr/local/go/src/math/rand/rand.go:127 +0xd2
  math/rand.(*Rand).Intn()
      /usr/local/go/src/math/rand/rand.go:144 +0x52
  math/rand.(*Rand).Perm()
      /usr/local/go/src/math/rand/rand.go:197 +0xa2
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).shuffleDial()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:109 +0x6f
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).connect()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:153 +0x114
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.NewSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/session.go:153 +0x141e
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/cluster.go:148 +0x8f
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).createSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:115 +0x173
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).Start()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:140 +0xbe
  github.com/znly/zenly-engine/common/services.Run.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:80 +0xc7

Previous write at 0x00c42023c008 by goroutine 21:
  math/rand.(*rngSource).Int63()
      /usr/local/go/src/math/rand/rng.go:231 +0xb9
  math/rand.(*Rand).Int63()
      /usr/local/go/src/math/rand/rand.go:81 +0x51
  math/rand.(*Rand).Int31()
      /usr/local/go/src/math/rand/rand.go:95 +0x38
  math/rand.(*Rand).Int31n()
      /usr/local/go/src/math/rand/rand.go:127 +0xd2
  math/rand.(*Rand).Intn()
      /usr/local/go/src/math/rand/rand.go:144 +0x52
  math/rand.(*Rand).Perm()
      /usr/local/go/src/math/rand/rand.go:197 +0xa2
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).shuffleDial()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:109 +0x6f
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*controlConn).connect()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/control.go:153 +0x114
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.NewSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/session.go:153 +0x141e
  github.com/znly/zenly-engine/vendor/github.com/gocql/gocql.(*ClusterConfig).CreateSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/gocql/gocql/cluster.go:148 +0x8f
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).createSession()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:115 +0x173
  github.com/znly/zenly-engine/common/services/svccassandra.(*Service).Start()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/svccassandra/svccassandra.go:140 +0xbe
  github.com/znly/zenly-engine/common/services.Run.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:80 +0xc7

Goroutine 87 (running) created at:
  github.com/znly/zenly-engine/common/services.Run()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:96 +0x1e7
  main.main.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:123 +0xe01
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:572 +0x801
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:662 +0x458
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:618 +0x38
  main.main()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:187 +0xf09

Goroutine 21 (running) created at:
  github.com/znly/zenly-engine/common/services.Run()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/common/services/services.go:96 +0x1e7
  main.main.func1()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:123 +0xe01
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:572 +0x801
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).ExecuteC()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:662 +0x458
  github.com/znly/zenly-engine/vendor/github.com/spf13/cobra.(*Command).Execute()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/vendor/github.com/spf13/cobra/command.go:618 +0x38
  main.main()
      /Users/quentinperez/go/src/github.com/znly/zenly-engine/cmd/zenlyengine/zenlyengine.go:187 +0xf09
```