### PR TITLE
Rebasing upon scylladb/gocql and making RetryPolicies coexist peacefully

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -55,6 +55,7 @@ type ClusterConfig struct {
 	Authenticator      Authenticator                            // authenticator (default: nil)
 	AuthProvider       func(h *HostInfo) (Authenticator, error) // an authenticator factory. Can be used to create alternative authenticators (default: nil)
 	RetryPolicy        RetryPolicy                              // Default retry policy to use for queries (default: 0)
+	DualRetryPolicy    DualRetryPolicy                          // Default retry policy to use for queries (default: 0)
 	ConvictionPolicy   ConvictionPolicy                         // Decide whether to mark host as down based on the error and host info (default: SimpleConvictionPolicy)
 	ReconnectionPolicy ReconnectionPolicy                       // Default reconnection policy to use for reconnecting before trying to mark host as down (default: see below)
 	SocketKeepalive    time.Duration                            // The keepalive period to use, enabled if > 0 (default: 0)
@@ -146,6 +147,18 @@ type ClusterConfig struct {
 
 	// internal config for testing
 	disableControlConn bool
+}
+
+func (cc *ClusterConfig) retryPolicy() DualRetryPolicy {
+	if cc.DualRetryPolicy != nil {
+		return cc.DualRetryPolicy
+	}
+
+	if cc.RetryPolicy != nil {
+		return newDualRetryPolicy(cc.RetryPolicy)
+	}
+
+	return nil
 }
 
 // NewCluster generates a new config for the default cluster implementation.

--- a/conn.go
+++ b/conn.go
@@ -609,10 +609,6 @@ func (c *Conn) releaseStream(stream int) {
 	delete(c.calls, stream)
 	c.mu.Unlock()
 
-	if call.timer != nil {
-		call.timer.Stop()
-	}
-
 	streamPool.Put(call)
 	c.streams.Clear(stream)
 }
@@ -633,6 +629,50 @@ var (
 	}
 )
 
+type safeTimer struct {
+	needStop bool
+	timer    *time.Timer
+}
+
+// Fired needs to be called read from C() succeeds.
+func (t *safeTimer) Fired() {
+	if t.timer == nil {
+		panic("invalid call to Fired timer was never started")
+	}
+	t.needStop = false
+}
+
+// C returns the timer channel or a nil channel that blocks forever if it was
+// not started.
+func (t *safeTimer) C() <-chan time.Time {
+	if t.timer == nil {
+		return nil
+	}
+	return t.timer.C
+}
+
+// Stop stops the timer. It is allowed to call Stop regardless of the timer
+// being started. It is also safe to be called multiple times.
+func (t *safeTimer) Stop() {
+	if t.timer == nil {
+		return
+	}
+	if t.needStop && !t.timer.Stop() {
+		<-t.timer.C
+	}
+	t.needStop = false
+}
+
+// Start lazy initializes and starts the timer.
+func (t *safeTimer) Start(d time.Duration) {
+	if t.timer == nil {
+		t.timer = time.NewTimer(d)
+	} else {
+		t.timer.Reset(d)
+	}
+	t.needStop = true
+}
+
 type callReq struct {
 	// could use a waitgroup but this allows us to do timeouts on the read/send
 	resp     chan error
@@ -640,7 +680,7 @@ type callReq struct {
 	timeout  chan struct{} // indicates to recv() that a call has timedout
 	streamID int           // current stream in use
 
-	timer *time.Timer
+	timer safeTimer
 }
 
 type deadlineWriter struct {
@@ -824,22 +864,8 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 		return nil, err
 	}
 
-	var timeoutCh <-chan time.Time
 	if c.timeout > 0 {
-		if call.timer == nil {
-			call.timer = time.NewTimer(0)
-			<-call.timer.C
-		} else {
-			if !call.timer.Stop() {
-				select {
-				case <-call.timer.C:
-				default:
-				}
-			}
-		}
-
-		call.timer.Reset(c.timeout)
-		timeoutCh = call.timer.C
+		call.timer.Start(c.timeout)
 	}
 
 	var ctxDone <-chan struct{}
@@ -849,6 +875,8 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 
 	select {
 	case err := <-call.resp:
+		// clear the timer before returning call to the pool.
+		call.timer.Stop()
 		close(call.timeout)
 		if err != nil {
 			if !c.Closed() {
@@ -860,14 +888,17 @@ func (c *Conn) exec(ctx context.Context, req frameWriter, tracer Tracer) (*frame
 			}
 			return nil, err
 		}
-	case <-timeoutCh:
+	case <-call.timer.C():
+		call.timer.Fired()
 		close(call.timeout)
 		c.handleTimeout()
 		return nil, ErrTimeoutNoResponse
 	case <-ctxDone:
+		call.timer.Stop()
 		close(call.timeout)
 		return nil, ctx.Err()
 	case <-c.quit:
+		call.timer.Stop()
 		return nil, ErrConnectionClosed
 	}
 

--- a/policies.go
+++ b/policies.go
@@ -160,6 +160,10 @@ type RetryPolicy interface {
 	GetRetryType(error) RetryType
 }
 
+type DualRetryPolicy interface {
+	AttemptWithError(RetryableQuery, error) (bool, bool)
+}
+
 // SimpleRetryPolicy has simple logic for attempting a query a fixed number of times.
 //
 // See below for examples of usage:

--- a/policies_test.go
+++ b/policies_test.go
@@ -266,10 +266,12 @@ func TestSimpleRetryPolicy(t *testing.T) {
 	q.metrics = &queryMetrics{m: make(map[string]*hostMetrics)}
 	for _, c := range cases {
 		q.metrics.m["127.0.0.1"] = &hostMetrics{Attempts: c.attempts}
-		if c.allow && !rt.Attempt(q) {
+		retry := rt.Attempt(q)
+		if c.allow && !retry {
 			t.Fatalf("should allow retry after %d attempts", c.attempts)
 		}
-		if !c.allow && rt.Attempt(q) {
+		retry = rt.Attempt(q)
+		if !c.allow && retry {
 			t.Fatalf("should not allow retry after %d attempts", c.attempts)
 		}
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -146,7 +146,8 @@ func TestQueryBasicAPI(t *testing.T) {
 	}
 
 	rt := &SimpleRetryPolicy{NumRetries: 3}
-	if qry.RetryPolicy(rt); qry.rt != rt {
+	qry.RetryPolicy(rt)
+	if qry.rt.(*retryPolicyWrapper).rt != rt {
 		t.Fatalf("expected Query.RetryPolicy to be '%v', got '%v'", rt, qry.rt)
 	}
 
@@ -192,8 +193,8 @@ func TestBatchBasicAPI(t *testing.T) {
 	b := s.NewBatch(UnloggedBatch)
 	if b.Type != UnloggedBatch {
 		t.Fatalf("expceted batch.Type to be '%v', got '%v'", UnloggedBatch, b.Type)
-	} else if b.rt != cfg.RetryPolicy {
-		t.Fatalf("expceted batch.RetryPolicy to be '%v', got '%v'", cfg.RetryPolicy, b.rt)
+	} else if b.rt.(*retryPolicyWrapper).rt != cfg.retryPolicy().(*retryPolicyWrapper).rt {
+		t.Fatalf("expceted batch.RetryPolicy to be '%v', got '%v'", cfg.retryPolicy(), b.rt)
 	}
 
 	// Test LoggedBatch
@@ -246,11 +247,11 @@ func TestBatchBasicAPI(t *testing.T) {
 	}
 
 	// Test RetryPolicy
-	r := &SimpleRetryPolicy{NumRetries: 4}
+	rt := &SimpleRetryPolicy{NumRetries: 4}
 
-	b.RetryPolicy(r)
-	if b.rt != r {
-		t.Fatalf("expected batch.RetryPolicy to be '%v', got '%v'", r, b.rt)
+	b.RetryPolicy(rt)
+	if b.rt.(*retryPolicyWrapper).rt != rt {
+		t.Fatalf("expected batch.RetryPolicy to be '%v', got '%v'", rt, b.rt)
 	}
 
 	if b.Size() != 2 {


### PR DESCRIPTION
This PR does two things:
- It cherry-picks all of our work (that wasn't mainlined yet) on top of `scylladb/gocql:master`
- It allows our custom `RetryPolicy` system to coexist peacefully with the mainline one

To ease review, this PR compares to `scylladb/gocql:master` rather than `gocql/gocql:master` (which is the current upstream of this repo).

All test pass, that's all I know:
```
go test -count=1 ./...
ok      github.com/znly/gocql   1.456s
ok      github.com/znly/gocql/internal/lru      0.001s
ok      github.com/znly/gocql/internal/murmur   0.001s
ok      github.com/znly/gocql/internal/streams  0.001s
```

You'll find a twin PR in zenly-engine to support this work: https://github.com/znly/zenly-engine/pull/1577