### PR TITLE
pushthat/fix querySharded not to exceed 100 pkey

### DIFF
--- a/session.go
+++ b/session.go
@@ -2184,6 +2184,7 @@ type ObservedShardedQuery struct {
 	// Whether this query was directed to a specific core or a specific host.
 	PerCore bool
 
+	// The number of page of QuerySizeMaximum
 	NumPages int
 }
 

--- a/session.go
+++ b/session.go
@@ -547,7 +547,7 @@ func (s *Session) querySharded(
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
-			queries = append(queries, s.Query(query, keys[i-numberToAddToThisPage:endIndexForThisPage]...))
+			queries = append(queries, s.Query(query, keys[i-QuerySizeMaximum:endIndexForThisPage]...))
 			numberOfPage--
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -536,7 +536,7 @@ func (s *Session) querySharded(
 			numberToAddToThisPage := QuerySizeMaximum
 			i += QuerySizeMaximum
 			if len(keys)-i < 0 {
-				numberToAddToThisPage = len(keys) - i + QuerySizeMaximum
+				numberToAddToThisPage = len(keys) + QuerySizeMaximum - i
 			}
 			endIndexForThisPage := i - QuerySizeMaximum + numberToAddToThisPage
 

--- a/session.go
+++ b/session.go
@@ -538,7 +538,7 @@ func (s *Session) querySharded(
 			if len(keys)-i < 0 {
 				numberToAddToThisPage = len(keys) + QuerySizeMaximum - i
 			}
-			endIndexForThisPage := i - QuerySizeMaximum + numberToAddToThisPage
+			endIndexForThisPage := i + numberToAddToThisPage - QuerySizeMaximum
 
 			query := strings.Replace(
 				stmt,

--- a/session.go
+++ b/session.go
@@ -2317,4 +2317,6 @@ func NewErrProtocol(format string, args ...interface{}) error {
 // BatchSizeMaximum is the maximum number of statements a batch operation can have.
 // This limit is set by cassandra and could change in the future.
 const BatchSizeMaximum = 65535
+
+// QuerySizeMaximum is the maximum amount of pkey that can be queried in a single query
 const QuerySizeMaximum = 100

--- a/session.go
+++ b/session.go
@@ -515,8 +515,8 @@ func (s *Session) querySharded(
 		// TODO(cmc): cache these?
 
 		numberOfPage := (len(keys) / QuerySizeMaximum) + 1
-		if len(keys) > QuerySizeMaximum && len(keys)%QuerySizeMaximum > 0 {
-			numberOfPage++
+		if len(keys) > QuerySizeMaximum && len(keys)%QuerySizeMaximum == 0 {
+			numberOfPage--
 		}
 
 		if observer := s.shardedQueryObserver; observer != nil {

--- a/session.go
+++ b/session.go
@@ -531,14 +531,12 @@ func (s *Session) querySharded(
 			})
 		}
 
-		i := 0
-		for numberOfPage > 0 {
-			numberToAddToThisPage := QuerySizeMaximum
-			i += QuerySizeMaximum
-			if len(keys)-i < 0 {
-				numberToAddToThisPage = len(keys) + QuerySizeMaximum - i
+		keysLeftToAdd := keys
+		for len(keysLeftToAdd) > 0 {
+			numberToAddToThisPage := len(keysLeftToAdd)
+			if len(keysLeftToAdd) > QuerySizeMaximum {
+				numberToAddToThisPage = QuerySizeMaximum
 			}
-			endIndexForThisPage := i + numberToAddToThisPage - QuerySizeMaximum
 
 			query := strings.Replace(
 				stmt,
@@ -547,8 +545,8 @@ func (s *Session) querySharded(
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
-			queries = append(queries, s.Query(query, keys[i-QuerySizeMaximum:endIndexForThisPage]...))
-			numberOfPage--
+			queries = append(queries, s.Query(query, keysLeftToAdd[:numberToAddToThisPage]...))
+			keysLeftToAdd = keysLeftToAdd[numberToAddToThisPage:]
 		}
 	}
 	return queries

--- a/session.go
+++ b/session.go
@@ -514,8 +514,8 @@ func (s *Session) querySharded(
 
 		// TODO(cmc): cache these?
 
-		numberOfPage := len(keys)/QuerySizeMaximum + 1
-		if len(keys)%QuerySizeMaximum > 0 {
+		numberOfPage := (len(keys) / QuerySizeMaximum) + 1
+		if len(keys) > QuerySizeMaximum && len(keys)%QuerySizeMaximum > 0 {
 			numberOfPage++
 		}
 

--- a/session.go
+++ b/session.go
@@ -530,7 +530,7 @@ func (s *Session) querySharded(
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", 1)+")",
+				"("+strings.Repeat("?,", len(keys))+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
@@ -542,7 +542,7 @@ func (s *Session) querySharded(
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", 1)+")",
+				"("+strings.Repeat("?,", QuerySizeMaximum)+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
@@ -553,7 +553,7 @@ func (s *Session) querySharded(
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", 1)+")",
+				"("+strings.Repeat("?,", i-len(keys))+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)

--- a/session.go
+++ b/session.go
@@ -524,25 +524,40 @@ func (s *Session) querySharded(
 		}
 
 		// TODO(cmc): cache these?
-		query := strings.Replace(
-			stmt,
-			_placeholder,
-			"("+strings.Repeat("?,", len(keys))+")",
-			-1,
-		)
-		query = strings.Replace(query, "?,)", "?)", -1)
 
 		numberOfPage := len(keys) / QuerySizeMaximum
 		if numberOfPage == 0 {
+			query := strings.Replace(
+				stmt,
+				_placeholder,
+				"("+strings.Repeat("?,", len(keys))+")",
+				-1,
+			)
+			query = strings.Replace(query, "?,)", "?)", -1)
 			return append(queries, s.Query(query, keys...))
 		}
 		i := 0
 		for numberOfPage > 0 {
 			i += QuerySizeMaximum
+			query := strings.Replace(
+				stmt,
+				_placeholder,
+				"("+strings.Repeat("?,", QuerySizeMaximum)+")",
+				-1,
+			)
+			query = strings.Replace(query, "?,)", "?)", -1)
 			queries = append(queries, s.Query(query, keys[i-QuerySizeMaximum:i]))
 			numberOfPage--
 		}
+		fmt.Println(i)
 		if len(keys)%QuerySizeMaximum > 0 {
+			query := strings.Replace(
+				stmt,
+				_placeholder,
+				"("+strings.Repeat("?,", i-len(keys))+")",
+				-1,
+			)
+			query = strings.Replace(query, "?,)", "?)", -1)
 			queries = append(queries, s.Query(query, keys[i:]))
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -546,7 +546,7 @@ func (s *Session) querySharded(
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
-			queries = append(queries, s.Query(query, keys[i-QuerySizeMaximum:i]))
+			queries = append(queries, s.Query(query, keys[i-QuerySizeMaximum:i]...))
 			numberOfPage--
 		}
 		if len(keys)%QuerySizeMaximum > 0 {
@@ -557,7 +557,7 @@ func (s *Session) querySharded(
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
-			queries = append(queries, s.Query(query, keys[i:]))
+			queries = append(queries, s.Query(query, keys[i:]...))
 		}
 	}
 	return queries

--- a/session.go
+++ b/session.go
@@ -530,7 +530,7 @@ func (s *Session) querySharded(
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", len(keys))+")",
+				"("+strings.Repeat("?,", 1)+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
@@ -542,19 +542,18 @@ func (s *Session) querySharded(
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", QuerySizeMaximum)+")",
+				"("+strings.Repeat("?,", 1)+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)
 			queries = append(queries, s.Query(query, keys[i-QuerySizeMaximum:i]))
 			numberOfPage--
 		}
-		fmt.Println(i)
 		if len(keys)%QuerySizeMaximum > 0 {
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", i-len(keys))+")",
+				"("+strings.Repeat("?,", 1)+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)

--- a/session.go
+++ b/session.go
@@ -553,7 +553,7 @@ func (s *Session) querySharded(
 			query := strings.Replace(
 				stmt,
 				_placeholder,
-				"("+strings.Repeat("?,", i-len(keys))+")",
+				"("+strings.Repeat("?,", len(keys)-i)+")",
 				-1,
 			)
 			query = strings.Replace(query, "?,)", "?)", -1)


### PR DESCRIPTION
- add pagination on shard aware query above 100 items
  - the IN query cannot use the iterator so if a IN query contains more then 100 item we will have an error from scylla when requesting stating that the query cannot exceed this limit